### PR TITLE
ACT-106 : Change WFL2 listing page to filter by Organization/Active level1 and not Country

### DIFF
--- a/workflow/views.py
+++ b/workflow/views.py
@@ -2519,6 +2519,7 @@ class Report(View, AjaxableResponseMixin):
     def get(self, request, *args, **kwargs):
 
         countries = get_country(request.user)
+        organization = request.user.activity_user.organization
 
         if int(self.kwargs['pk']) != 0:
             get_agreements = ProjectAgreement.objects.all().filter(
@@ -2528,11 +2529,11 @@ class Report(View, AjaxableResponseMixin):
             get_agreements = ProjectAgreement.objects.all().filter(
                 approval=self.kwargs['status'])
         else:
-            get_agreements = ProjectAgreement.objects.select_related().filter(
-                program__country__in=countries)
+            get_agreements = ProjectAgreement.objects.filter(
+                program__organization=organization)
 
         get_programs = Program.objects.all().filter(
-            funding_status="Funded", country__in=countries).distinct()
+            funding_status="Funded", organization=organization).distinct()
 
         filtered = ProjectAgreementFilter(request.GET, queryset=get_agreements)
         table = ProjectAgreementTable(filtered.queryset)
@@ -2565,15 +2566,14 @@ class ReportData(View, AjaxableResponseMixin):
     """
 
     def get(self, request, *args, **kwargs):
-
-        countries = get_country(request.user)
+        organization = request.user.activity_user.organization
         filters = {}
         if int(self.kwargs['pk']) != 0:
             filters['program__id'] = self.kwargs['pk']
         elif self.kwargs['status'] != 'none':
             filters['approval'] = self.kwargs['status']
         else:
-            filters['program__country__in'] = countries
+            filters['program__organization'] = organization
 
         get_agreements = ProjectAgreement.objects.prefetch_related('sectors') \
             .select_related('program', 'project_type', 'office',


### PR DESCRIPTION
## What is the Purpose?
Change WFL2 listing (project) in the "Reports/WFL2 Report" page to filter by organization and selected WFL1 and not country.

## What was the approach?
Check transmitted data in workflow Report and ReportData views.

## Are there any concerns to addressed further before or after merging this PR?
-

## Mentions?
@henryohanga @odenypeter

## Issue(s) affected?
ACT-106